### PR TITLE
if not specified -n -> regenerate all files

### DIFF
--- a/moonworm/cli.py
+++ b/moonworm/cli.py
@@ -88,6 +88,25 @@ def handle_brownie_generate(args: argparse.Namespace):
     project_directory = args.project
     build_directory = os.path.join(project_directory, "build", "contracts")
 
+    if not args.name:
+
+        for file in os.listdir(build_directory):
+            filename = os.fsdecode(file)
+
+            if filename.endswith(".json"):
+                args.name = os.path.splitext(filename)[0]
+                handle_brownie_generate_file(args)
+    else:
+        handle_brownie_generate_file(args)
+
+
+def handle_brownie_generate_file(args: argparse.Namespace):
+
+    Path(args.outdir).mkdir(exist_ok=True)
+
+    project_directory = args.project
+    build_directory = os.path.join(project_directory, "build", "contracts")
+
     build_file_path = os.path.join(build_directory, f"{args.name}.json")
     if not os.path.isfile(build_file_path):
         raise IOError(
@@ -303,8 +322,8 @@ def generate_argument_parser() -> argparse.ArgumentParser:
     generate_brownie_parser.add_argument(
         "--name",
         "-n",
-        required=True,
-        help="Prefix name for generated files",
+        required=False,
+        help="Prefix name for generated files (optional, if not specified will regenerate all)",
     )
     generate_brownie_parser.add_argument(
         "-p",


### PR DESCRIPTION
<!-- Thank you for your contribution. -->
<!-- Filling in the sections below will provide us with some context when we are reviewing your pull request. -->

## Changes
This PR makes `-n` argument optional, now if you don't supply file name - it will regenerate all interfaces for brownie at once 

<!-- Please leave a short description of the changes you have made in this pull request. -->
<!-- If applicable, this is the place to discuss alternatives you considered and tradeoffs you made. -->

## How to test these changes?


<!-- Describe how you tested the changes in this pull request. -->
<!-- Describe how someone else could reproduce your tests. -->

## Related issues

<!-- Is this PR related to any of the issues at https://github.com/orgs/bugout-dev/projects/3 ? -->
<!-- If this PR resolves any of those issues, add a line in the format "Resolves <link to isssue>". -->

<!-- Thanks again! :) -->
